### PR TITLE
Fix: make DependencyLoader agnostic with path delimiter (fixes #9)

### DIFF
--- a/lib/DependencyLoader.js
+++ b/lib/DependencyLoader.js
@@ -2,6 +2,7 @@
 import _ from 'lodash'
 import fs from 'fs-extra'
 import { glob } from 'glob'
+import path from 'path'
 import Hook from './Hook.js'
 import Utils from './Utils.js'
 /**
@@ -87,7 +88,7 @@ class DependencyLoader {
     /** @ignore */ this._configsLoaded = false
     const files = await glob(`${this.app.rootDir}/node_modules/**/${Utils.metadataFileName}`)
     const deps = files
-      .map(d => d.replace(`/${Utils.metadataFileName}`, ''))
+      .map(d => d.replace(`${Utils.metadataFileName}`, ''))
       .sort((a, b) => a.length < b.length ? -1 : 1)
 
     const configCache = {}
@@ -122,8 +123,8 @@ class DependencyLoader {
    */
   async loadModuleConfig (modDir) {
     return {
-      ...await fs.readJson(`${modDir}/${Utils.packageFileName}`),
-      ...await fs.readJson(`${modDir}/${Utils.metadataFileName}`),
+      ...await fs.readJson(path.join(modDir, Utils.packageFileName)),
+      ...await fs.readJson(path.join(modDir, Utils.metadataFileName)),
       rootDir: modDir
     }
   }


### PR DESCRIPTION
#9 

[//]: # (Delete as appropriate)
### Fix
* Make DependencyLoader agnostic with path delimiter