### PR TITLE
Fix: Fall back to core result when middleware observer omits return

### DIFF
--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -96,13 +96,19 @@ class Hook {
    * @return {Promise}
    */
   async _invokeMiddleware (coreFn, ...args) {
-    let fn = coreFn
+    let coreResult
+    const wrappedCoreFn = async (...a) => {
+      coreResult = await coreFn(...a)
+      return coreResult
+    }
+    let fn = wrappedCoreFn
     for (let i = this._hookObservers.length - 1; i >= 0; i--) {
       const observer = this._hookObservers[i]
       const next = fn
       fn = (...a) => observer(next, ...a)
     }
-    return fn(...args)
+    const result = await fn(...args)
+    return result !== undefined ? result : coreResult
   }
 }
 

--- a/tests/Hook.spec.js
+++ b/tests/Hook.spec.js
@@ -483,6 +483,36 @@ describe('Hook', () => {
         const result = await hook.invoke(core, 1)
         assert.equal(result, 2)
       })
+
+      it('should fall back to core result when observer calls next() without returning', async () => {
+        const hook = new Hook({ type: Hook.Types.Middleware })
+        hook.tap(async (next, val) => {
+          await next(val) // calls next but doesn't return the result
+        })
+        const core = async (val) => val * 3
+        const result = await hook.invoke(core, 7)
+        assert.equal(result, 21)
+      })
+
+      it('should fall back to core result through multiple non-returning observers', async () => {
+        const hook = new Hook({ type: Hook.Types.Middleware })
+        hook.tap(async (next, val) => { await next(val) })
+        hook.tap(async (next, val) => { await next(val) })
+        const core = async (val) => ({ id: val })
+        const result = await hook.invoke(core, 42)
+        assert.deepEqual(result, { id: 42 })
+      })
+
+      it('should prefer explicit observer return over core result fallback', async () => {
+        const hook = new Hook({ type: Hook.Types.Middleware })
+        hook.tap(async (next, val) => {
+          await next(val)
+          return 'transformed'
+        })
+        const core = async (val) => val
+        const result = await hook.invoke(core, 'original')
+        assert.equal(result, 'transformed')
+      })
     })
   })
 


### PR DESCRIPTION
### Fix
* Middleware hooks now fall back to the core function's return value when an observer calls `next()` but doesn't return the result

### Testing
1. Run `node --test tests/Hook.spec.js` — 60 tests pass (3 new)
2. New tests cover: single non-returning observer, multiple non-returning observers, and explicit return taking priority over fallback

Fixes #101