### PR TITLE
Update: Add releases workflow badge to generated docs

### DIFF
--- a/docs/plugins/coremodules.js
+++ b/docs/plugins/coremodules.js
@@ -11,7 +11,7 @@ export default class CoreModules {
 
   async getWorkflowBadges (homepage) {
     if (!homepage) return []
-    const workflows = ['tests', 'standardjs']
+    const workflows = ['tests', 'standardjs', 'releases']
     const results = await Promise.all(workflows.map(async w => {
       const url = `${homepage}/actions/workflows/${w}.yml`
       const badgeUrl = `${url}/badge.svg`


### PR DESCRIPTION
### Update
* Include the `releases` workflow badge alongside `tests` and `standardjs` in the generated core modules documentation

### Testing
1. Run the docs generation and verify the releases badge appears in the output table