### PR TITLE
Fix: Windows path handling in config import and module discovery (fixes #122)

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1,6 +1,7 @@
 import { Schemas } from 'adapt-schemas'
 import fs from 'fs/promises'
 import path from 'path'
+import { pathToFileURL } from 'url'
 
 /**
  * Loads, validates, and provides access to application configuration.
@@ -91,7 +92,7 @@ class Config {
     let config
     try {
       await fs.readFile(this.configFilePath)
-      config = (await import(this.configFilePath)).default
+      config = (await import(pathToFileURL(this.configFilePath).href)).default
     } catch (e) {
       this.log('warn', 'config', `Failed to load config at ${this.configFilePath}: ${e}. Will attempt to run with defaults.`)
       return

--- a/lib/DependencyLoader.js
+++ b/lib/DependencyLoader.js
@@ -64,7 +64,7 @@ class DependencyLoader {
   async loadConfigs () {
     /** @ignore */ this._configsLoaded = false
     const corePathSegment = `/${this.app.name}/`
-    const files = await glob(`${this.app.rootDir}/node_modules/**/${metadataFileName}`)
+    const files = await glob(`node_modules/**/${metadataFileName}`, { cwd: this.app.rootDir, absolute: true, posix: true })
     const deps = files
       .map(d => d.replace(`${metadataFileName}`, ''))
       .sort((a, b) => {

--- a/tests/Config.spec.js
+++ b/tests/Config.spec.js
@@ -1,7 +1,12 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import Config from '../lib/Config.js'
+import fs from 'fs/promises'
+import os from 'os'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const dataDir = fileURLToPath(new URL('./data', import.meta.url))
 
 describe('Config', () => {
   describe('constructor', () => {
@@ -117,6 +122,29 @@ describe('Config', () => {
       const config = new Config()
       config.configFilePath = '/nonexistent/path/config.js'
       await assert.doesNotReject(() => config.storeUserSettings())
+    })
+
+    it('should load and flatten settings from the config file', async () => {
+      const config = new Config()
+      config.configFilePath = path.join(dataDir, 'user-config.js')
+      await config.storeUserSettings()
+      assert.equal(config.get('adapt-authoring-core.dataDir'), '/app/APP_DATA/data')
+      assert.equal(config.get('adapt-authoring-server.port'), 5000)
+    })
+
+    it('should load a config file whose path contains URL-significant characters', async () => {
+      // import() parses a bare path as a URL, so '#' (and Windows drive letters, core#122) break it
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'adapt-cfg-#'))
+      const file = path.join(dir, 'config.js')
+      try {
+        await fs.writeFile(file, "export default { 'adapt-authoring-core': { dataDir: '/from/weird/path' } }\n")
+        const config = new Config()
+        config.configFilePath = file
+        await config.storeUserSettings()
+        assert.equal(config.get('adapt-authoring-core.dataDir'), '/from/weird/path')
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true })
+      }
     })
   })
 })

--- a/tests/DependencyLoader.spec.js
+++ b/tests/DependencyLoader.spec.js
@@ -131,6 +131,22 @@ describe('DependencyLoader', () => {
       const names = Object.keys(loader.configs)
       assert.equal(names[0], 'adapt-authoring-core')
     })
+
+    it('should load configs when rootDir contains glob-significant characters', async () => {
+      // interpolating rootDir into the pattern would parse '[id]' as a char class (and '\' as an escape on Windows)
+      const root = path.join(__dirname, 'data', 'loadconfigs-root[id]')
+      const coreDir = path.join(root, 'node_modules', 'adapt-authoring-core')
+      try {
+        await fs.ensureDir(coreDir)
+        await fs.writeJson(path.join(coreDir, 'package.json'), { name: 'adapt-authoring-core' })
+        await fs.writeJson(path.join(coreDir, 'adapt-authoring.json'), { module: false })
+        const loader = new DependencyLoader({ rootDir: root, name: 'adapt-authoring-core' })
+        await loader.loadConfigs()
+        assert.ok(loader.configs['adapt-authoring-core'])
+      } finally {
+        await fs.remove(root)
+      }
+    })
   })
 
   describe('#loadConfigs() with nested duplicate', () => {

--- a/tests/data/user-config.js
+++ b/tests/data/user-config.js
@@ -1,0 +1,8 @@
+export default {
+  'adapt-authoring-core': {
+    dataDir: '/app/APP_DATA/data'
+  },
+  'adapt-authoring-server': {
+    port: 5000
+  }
+}


### PR DESCRIPTION
### Fixes #122

### Fix
- `Config.storeUserSettings()` passed a bare filesystem path to dynamic `import()`. Node's ESM loader parses the specifier as a URL, so a Windows drive-letter path (`C:\…`) is read as a URL scheme and throws `ERR_UNSUPPORTED_ESM_URL_SCHEME`. The path is now converted to a `file:` URL with `pathToFileURL(...).href`.
- `DependencyLoader.loadConfigs()` interpolated `rootDir` into a glob pattern (`${rootDir}/node_modules/**/adapt.json`). On Windows the `\` separators are interpreted as glob escape characters, so no modules are discovered and the app fails to boot. The path is now passed via the `cwd` option with `absolute: true, posix: true`, which keeps forward-slash results on every platform (the downstream sort relies on `/`).

### Testing
- `Config`: added coverage for `storeUserSettings()` (previously only the missing-file branch was tested) — loads a fixture, and loads a config from a path containing URL-significant characters (`#`), a portable guard that fails without the fix on all platforms.
- `DependencyLoader`: added a `loadConfigs()` test using a `rootDir` containing glob-significant characters (`[id]`), which fails without the fix on all platforms.