### PR TITLE
Update: add build-time branding image config keys

### DIFF
--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -82,6 +82,10 @@
     "projectPlaceholder": {
       "description": "Absolute path to a custom image to bake into the UI build as the default course/project thumbnail (used when a course has no hero image). Leave unset to use the built-in placeholder.",
       "type": "string"
+    },
+    "loginBackground": {
+      "description": "Absolute path to a custom full-screen login background image, served as a static asset by the UI build. Leave unset to use the built-in background.",
+      "type": "string"
     }
   }
 }

--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -78,6 +78,10 @@
     "logo": {
       "description": "Absolute path to a custom logo image (PNG recommended — email-safe) to bake into the UI build (overrides the built-in mark) and reuse in branded emails. Leave unset to use the built-in logo.",
       "type": "string"
+    },
+    "projectPlaceholder": {
+      "description": "Absolute path to a custom image to bake into the UI build as the default course/project thumbnail (used when a course has no hero image). Leave unset to use the built-in placeholder.",
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
### Fixes #124

### Update
- Add `projectPlaceholder` — absolute path to a custom default course/project thumbnail (shown when a course has no hero image), baked into the UI build.
- Add `loginBackground` — absolute path to a custom full-screen login background image, served as a static asset by the UI build.

Both sit alongside `logo`, are additive and backwards-compatible (unset falls back to the built-in default), and are consumed by adapt-authoring-ui (cgkineo/adapt-authoring-ui#67).

### Testing
- Schema is valid JSON; both keys are optional (no `required` change), so existing configs are unaffected.
- Consumed by cgkineo/adapt-authoring-ui#67 — merge/release this first so the keys validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)