### PR TITLE
New: add favicon branding config key (fixes #128)

### DIFF
--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -86,6 +86,10 @@
     "loginBackground": {
       "description": "Absolute path to a custom full-screen login background image, served as a static asset by the UI build. Leave unset to use the built-in background.",
       "type": "string"
+    },
+    "favicon": {
+      "description": "Absolute path to a custom favicon (SVG recommended) baked into the UI build's browser-tab icon (overrides the built-in mark). Leave unset to use the built-in favicon.",
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
### Fixes #128

### New
* Add a `favicon` string key to the config schema (absolute path to a custom favicon, SVG recommended), alongside the other brand-image keys. Consumed by the adapt-authoring-ui build (companion PR cgkineo/adapt-authoring-ui#77).
