### PR TITLE
Chore: remove orphaned deprecated conf migration maps

### DIFF
--- a/conf/deprecated-lang.json
+++ b/conf/deprecated-lang.json
@@ -1,4 +1,0 @@
-{
-  "_module": "adapt-authoring-lang",
-  "defaultLang": "adapt-authoring-core.defaultLang"
-}

--- a/conf/deprecated-logger.json
+++ b/conf/deprecated-logger.json
@@ -1,7 +1,0 @@
-{
-  "_module": "adapt-authoring-logger",
-  "levels": "adapt-authoring-core.logLevels",
-  "showTimestamp": "adapt-authoring-core.showLogTimestamp",
-  "mute": null,
-  "dateFormat": null
-}


### PR DESCRIPTION
### Fixes #130

### Fix
- Remove `conf/deprecated-lang.json` and `conf/deprecated-logger.json` — dead config-key migration maps from the 3.0.0 lang/logger→core consolidation. Nothing reads them: `lib/Config.js` has no deprecated-key handling, and the equivalent mapping now lives in `migrations/3.0.0-conf-migrate-lang-config.js` / `migrations/3.0.0-conf-migrate-logger-config.js` (encoded inline via the migration API).

### Testing
- Org-wide code search confirms zero references to the removed filenames.
- Migration scripts are untouched, so the 3.0.0 conf migration path is unaffected.