### PR TITLE
Update: expose ordered, authoritative Logger.levels (fixes #132)

### DIFF
--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -16,12 +16,24 @@ class Logger {
   }
 
   /**
+   * Log level names in descending order of severity (most-severe first). This
+   * ordering is authoritative: consumers that threshold or rank levels — e.g.
+   * "this level and everything more severe" — must derive from it, never
+   * hardcode their own list. Backed by {@link Logger.levelColours} so the
+   * names, their order, and their colours stay a single source of truth.
+   * @type {Array<String>}
+   */
+  static get levels () {
+    return Object.keys(Logger.levelColours)
+  }
+
+  /**
    * Creates a Logger instance from config values
    * @param {Object} options
    * @param {Array<String>} options.levels Log level config strings. An empty array mutes all output.
    * @param {Boolean} options.showTimestamp Whether to show timestamps
    */
-  constructor ({ levels = Object.keys(Logger.levelColours), showTimestamp = true } = {}) {
+  constructor ({ levels = Logger.levels, showTimestamp = true } = {}) {
     /**
      * Hook invoked on each message logged
      * @type {Hook}
@@ -102,7 +114,7 @@ class Logger {
    * @return {Array<String>}
    */
   static getIdOverrides (levelsConfig) {
-    const knownLevels = Object.keys(Logger.levelColours)
+    const knownLevels = Logger.levels
     return levelsConfig.filter(entry => {
       const body = entry.startsWith('!') ? entry.slice(1) : entry
       const firstSegment = body.split('.')[0]

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -2,30 +2,45 @@ import chalk from 'chalk'
 import Hook from './Hook.js'
 
 /**
+ * Log levels in descending order of severity (most-severe first), each paired
+ * with its console colour. This is the single source of truth for the level
+ * set, their severity ordering, and their colours — `Logger.levels` and
+ * `Logger.levelColours` are both derived from it. The order is authoritative,
+ * so a level is added/removed/reordered here and nowhere else.
+ */
+const LEVELS = [
+  { name: 'error', colour: chalk.red },
+  { name: 'warn', colour: chalk.yellow },
+  { name: 'success', colour: chalk.green },
+  { name: 'info', colour: chalk.cyan },
+  { name: 'debug', colour: chalk.dim },
+  { name: 'verbose', colour: chalk.grey.italic }
+]
+
+/**
  * Provides console logging with configurable levels, colours, and module-specific overrides.
  * @memberof core
  */
 class Logger {
-  static levelColours = {
-    error: chalk.red,
-    warn: chalk.yellow,
-    success: chalk.green,
-    info: chalk.cyan,
-    debug: chalk.dim,
-    verbose: chalk.grey.italic
-  }
-
   /**
    * Log level names in descending order of severity (most-severe first). This
    * ordering is authoritative: consumers that threshold or rank levels — e.g.
    * "this level and everything more severe" — must derive from it, never
-   * hardcode their own list. Backed by {@link Logger.levelColours} so the
-   * names, their order, and their colours stay a single source of truth.
+   * hardcode their own list.
    * @type {Array<String>}
    */
   static get levels () {
-    return Object.keys(Logger.levelColours)
+    return LEVELS.map(l => l.name)
   }
+
+  /**
+   * Console colour function keyed by level name.
+   * @type {Object}
+   */
+  static levelColours = LEVELS.reduce((m, { name, colour }) => {
+    m[name] = colour
+    return m
+  }, {})
 
   /**
    * Creates a Logger instance from config values

--- a/tests/Logger.spec.js
+++ b/tests/Logger.spec.js
@@ -28,6 +28,16 @@ describe('Logger', () => {
     })
   })
 
+  describe('.levels', () => {
+    it('should list every level in levelColours', () => {
+      assert.deepEqual([...Logger.levels].sort(), Object.keys(Logger.levelColours).sort())
+    })
+
+    it('should order levels by descending severity', () => {
+      assert.deepEqual(Logger.levels, ['error', 'warn', 'success', 'info', 'debug', 'verbose'])
+    })
+  })
+
   describe('.isLevelEnabled()', () => {
     it('should return true when level is in config', () => {
       assert.equal(Logger.isLevelEnabled(['error', 'warn'], 'error'), true)

--- a/tests/Logger.spec.js
+++ b/tests/Logger.spec.js
@@ -29,12 +29,16 @@ describe('Logger', () => {
   })
 
   describe('.levels', () => {
-    it('should list every level in levelColours', () => {
-      assert.deepEqual([...Logger.levels].sort(), Object.keys(Logger.levelColours).sort())
-    })
-
     it('should order levels by descending severity', () => {
       assert.deepEqual(Logger.levels, ['error', 'warn', 'success', 'info', 'debug', 'verbose'])
+    })
+
+    it('should derive levelColours from the same source, in the same order', () => {
+      assert.deepEqual(Object.keys(Logger.levelColours), Logger.levels)
+    })
+
+    it('should map every level to a colour function', () => {
+      Logger.levels.forEach(level => assert.equal(typeof Logger.levelColours[level], 'function'))
     })
   })
 


### PR DESCRIPTION
### Fixes #132

### Update
- Introduce a single ordered `LEVELS` array — the level names in **descending order of severity** (`error, warn, success, info, debug, verbose`), each paired with its console colour. This is now the one source of truth for the level set, their severity ordering, **and** their colours; a level is added/removed/reordered here and nowhere else.
- Derive both public accessors from it:
  - `Logger.levels` — the level names in severity order. Consumers that need to threshold or rank levels (e.g. "this level and everything more severe") derive from it instead of hardcoding their own copy, which would drift if a level changes.
  - `Logger.levelColours` — the colour map, now built from `LEVELS` rather than being the de-facto source of the ordering. Its shape/keys are unchanged, so existing consumers are unaffected.
- Previously the severity ordering was an implicit byproduct of the colour map's key insertion order; the JSDoc now states the array's order is authoritative so it can't be silently broken by a cosmetic reorder.
- Dogfood `Logger.levels` at the two existing `Object.keys(Logger.levelColours)` call sites (constructor default + `getIdOverrides`).

### Testing
- Unit tests assert `Logger.levels` holds the descending-severity order, that `levelColours` is derived from the same source in the same order, and that every level maps to a colour function.
- Full suite `310/310`, `standard` clean.
